### PR TITLE
Lazily look up the popup type

### DIFF
--- a/lib/torii/bootstrap/torii.js
+++ b/lib/torii/bootstrap/torii.js
@@ -35,13 +35,6 @@ export default function(application) {
   application.register('torii-service:iframe', IframeService);
   application.register('torii-service:popup', PopupService);
 
-  var remoteServiceName = configuration.remoteServiceName || 'popup';
-  if(remoteServiceName === 'iframe'){
-    application.inject('torii-provider', 'popup', 'torii-service:iframe');
-  }else{
-    application.inject('torii-provider', 'popup', 'torii-service:popup');
-  }
-
   if (window.DS) {
     var storeFactoryName = 'store:main';
     if (hasRegistration(application, 'service:store')) {

--- a/lib/torii/instance-initializers/walk-providers.js
+++ b/lib/torii/instance-initializers/walk-providers.js
@@ -7,13 +7,9 @@ export default {
     // Walk all configured providers and eagerly instantiate
     // them. This gives providers with initialization side effects
     // like facebook-connect a chance to load up assets.
-    for (var key in  configuration.providers) {
+    for (var key in configuration.providers) {
       if (configuration.providers.hasOwnProperty(key)) {
-        var provider = lookup(applicationInstance, 'torii-provider:'+key);
-        var provider_config = configuration.providers[key];
-        if(provider_config.remoteServiceName){
-          provider.set('popup', lookup(applicationInstance, 'torii-service:'+provider_config.remoteServiceName));
-        }
+        lookup(applicationInstance, 'torii-provider:'+key);
       }
     }
 

--- a/lib/torii/lib/container-utils.js
+++ b/lib/torii/lib/container-utils.js
@@ -33,3 +33,11 @@ export function lookup(applicationInstance, name) {
     return applicationInstance.container.lookup(name);
   }
 }
+
+export function getOwner(instance) {
+  if (Ember.getOwner) {
+    return Ember.getOwner(instance);
+  } else {
+    return instance.container;
+  }
+}

--- a/lib/torii/providers/base.js
+++ b/lib/torii/providers/base.js
@@ -1,4 +1,9 @@
 import requiredProperty from 'torii/lib/required-property';
+import { getOwner } from 'torii/lib/container-utils';
+import { configurable } from 'torii/configuration';
+import configuration from 'torii/configuration';
+
+var DEFAULT_REMOTE_SERVICE_NAME = 'popup';
 
 var computed = Ember.computed;
 
@@ -19,9 +24,21 @@ var Base = Ember.Object.extend({
    * that holds config information for this provider.
    * @property {string} configNamespace
    */
-  configNamespace: computed('name', function(){
+  configNamespace: computed('name', function() {
     return 'providers.'+this.get('name');
-  })
+  }),
+
+  popup: computed('configuredRemoteServiceName', function() {
+    var owner = getOwner(this);
+    var remoteServiceName = (
+      this.get('configuredRemoteServiceName') ||
+      configuration.remoteServiceName ||
+      DEFAULT_REMOTE_SERVICE_NAME
+    );
+    return owner.lookup('torii-service:'+remoteServiceName);
+  }),
+
+  configuredRemoteServiceName: configurable('remoteServiceName', null)
 
 });
 

--- a/test/tests/unit/bootstrap/torii-test.js
+++ b/test/tests/unit/bootstrap/torii-test.js
@@ -1,21 +1,59 @@
 import toriiContainer from 'test/helpers/torii-container';
+import BaseProvider from 'torii/providers/base';
+import IframeService from 'torii/services/iframe';
+import PopupService from 'torii/services/popup';
+import configuration from 'torii/configuration';
 
-var container, registry;
+var container, registry, FooProvider;
 
 module("boostrapTorii", {
-  teardown: function(){
+  setup: function() {
+    FooProvider = BaseProvider.extend({
+      name: 'foo'
+    });
+  },
+  teardown: function() {
     Ember.run(container, 'destroy');
     registry = container = null;
+    FooProvider = null;
     window.DS = null;
+    delete configuration.remoteServiceName;
+    delete configuration.providers.foo;
   }
 });
 
-test("inject popup onto providers", function(){
+test("default popup on providers", function(){
   var results = toriiContainer();
   registry = results[0];
   container = results[1];
-  registry.register('torii-provider:foo', Ember.Object.extend());
-  ok(container.lookup('torii-provider:foo').get('popup'), 'Popup is set');
+  registry.register('torii-provider:foo', FooProvider);
+  var popup = container.lookup('torii-provider:foo').get('popup');
+  ok(popup, 'Popup is set');
+  ok(popup instanceof PopupService, 'Popup service is popup');
+});
+
+test("configured default popup", function(){
+  configuration.remoteServiceName = 'iframe';
+  var results = toriiContainer();
+  registry = results[0];
+  container = results[1];
+  registry.register('torii-provider:foo', FooProvider);
+  var popup = container.lookup('torii-provider:foo').get('popup');
+  ok(popup, 'Popup is set');
+  ok(popup instanceof IframeService, 'Popup service is iframe');
+});
+
+test("configured popup on providers", function(){
+  configuration.providers.foo = {
+    remoteServiceName: 'iframe'
+  };
+  var results = toriiContainer();
+  registry = results[0];
+  container = results[1];
+  registry.register('torii-provider:foo', FooProvider);
+  var popup = container.lookup('torii-provider:foo').get('popup');
+  ok(popup, 'Popup is set');
+  ok(popup instanceof IframeService, 'Popup service is iframe');
 });
 
 test("inject legacy DS store onto providers, adapters", function(){
@@ -27,7 +65,7 @@ test("inject legacy DS store onto providers, adapters", function(){
   registry = results[0];
   container = results[1];
 
-  registry.register('torii-provider:foo', Ember.Object.extend());
+  registry.register('torii-provider:foo', FooProvider);
   var provider = container.lookup('torii-provider:foo');
   ok(provider.get('store'), 'Store is set on providers');
 
@@ -45,7 +83,7 @@ test("inject DS store onto providers, adapters", function(){
   registry = results[0];
   container = results[1];
 
-  registry.register('torii-provider:foo', Ember.Object.extend());
+  registry.register('torii-provider:foo', FooProvider);
   var provider = container.lookup('torii-provider:foo');
   ok(provider.get('store'), 'Store is set on providers');
 


### PR DESCRIPTION
@jagthedrummer a PR with lazy popup discovery, using the same `configurable` properties we use elsewhere. This does require that providers inherit from `BaseProvider`, but that is reasonable to me and I think we're been suggesting it for a while.
